### PR TITLE
[refact] Counter Comp. className관련 개선  #113

### DIFF
--- a/src/components/Counter/Counter.jsx
+++ b/src/components/Counter/Counter.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import Count from './Count';
 import CountButton from './CountButton';
+import classNames from 'classnames';
 import classes from '@/components/Counter/Counter.module.scss';
 import { ReactComponent as PlusBlack } from '@/assets/img-plus-black.svg';
 import { ReactComponent as MinusBlack } from '@/assets/img-minus-black.svg';
@@ -10,7 +11,7 @@ import { ReactComponent as MinusGray } from '@/assets/img-minus-gray.svg';
  *
  * @param {*} setParentState 부모 컴포넌트의 state를 set, update하는 함수를 argument로 요구합니다. 카운트가 증가하고 감소함에 따라 자동으로 부모 컴포넌트의 state도 update해줍니다.
  */
-export default function Counter({ setParentState = null }) {
+export default function Counter({ setParentState = null, className = null }) {
   const [count, setCount] = useState(0);
 
   useEffect(() => {
@@ -29,7 +30,7 @@ export default function Counter({ setParentState = null }) {
   };
 
   return (
-    <span className={classes.counter}>
+    <span className={classNames(classes.counter, className)}>
       <CountButton
         onClick={minusCount}
         aria-label={count === 0 ? '비활성화 된 마이너스 버튼' : '마이너스 버튼'}


### PR DESCRIPTION
## ✨ 구현 기능 개요
- 컴포넌트 태그 자체에 className 전달
- 코드 가독성 개선

## 🔨 작업사항
- className을 컴포넌트 태그 차원에서 전달할 수 있게 개선

<img width="779" alt="스크린샷 2023-03-18 오전 12 59 50" src="https://user-images.githubusercontent.com/54176384/225956609-f7a49562-196f-4ea0-b820-03fcc852e7df.png">
위 사진과 같이 <Counter /> 컴포넌트에 className={~~~}를 전달할 수 있습니다. 전달시 내부적으로 컴포넌트를 구성하고 있는 최상위 요소에 그 className이 전달됩니다.

- classNames plug-in을 이용해 코드 가독성 향상

## ⏰ 소요시간
1시간