### PR TITLE
Refact | Header, Footer 레이아웃 및 디테일 수정

### DIFF
--- a/src/components/Header/header.module.scss
+++ b/src/components/Header/header.module.scss
@@ -3,6 +3,9 @@
   display: flex;
   flex-flow: column;
   align-items: center;
+  background-color: white;
+  min-width: 65.625rem;
+  justify-content: center;
 }
 
 .gapDiv {

--- a/src/components/Header/nav.module.scss
+++ b/src/components/Header/nav.module.scss
@@ -3,6 +3,7 @@
   display: flex;
   justify-content: space-between;
   width: 65.625rem;
+  position: relative;
 
   button:nth-child(-n + 1) {
     border: none;
@@ -23,7 +24,7 @@
   position: static;
   width: 100%;
   top: 105px;
-  box-shadow: 0 4px 8px #eeeeeeee;
+  box-shadow: 0 5px 8px rgba(0, 0, 0, 0.1);
 }
 
 .fixedNavigation {
@@ -35,13 +36,33 @@
   width: 100%;
   justify-content: center;
   top: 0px;
-  box-shadow: 0 4px 8px #eeeeeeee;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  min-width: 65.625rem;
+
+  .utilityButtonList {
+    display: flex;
+    width: fit-content;
+    height: fit-content;
+    button {
+      cursor: pointer;
+      border: none;
+      background-color: transparent;
+      width: 2.25rem;
+      height: 2.25rem;
+      padding: 0;
+
+      &:nth-child(n + 2) {
+        margin-left: 1.25rem;
+      }
+    }
+  }
 }
 .categoryButton {
-  width: 5.75rem;
+  width: fit-content;
   height: 2.5rem;
-  position: relative;
+
   span {
+    padding: 24px 0;
     display: flex;
     align-items: center;
   }
@@ -51,8 +72,10 @@
   }
 
   ul {
+    background-color: white;
     position: absolute;
-
+    top: 62px;
+    left: 0;
     margin-top: 10px;
     display: none;
     text-align: left;

--- a/src/components/Header/searchBar.module.scss
+++ b/src/components/Header/searchBar.module.scss
@@ -1,9 +1,8 @@
 .searchBar {
   display: flex;
   overflow: hidden;
-  height: 4.625rem;
+  height: fit-content;
   width: 65.625rem;
-
   justify-content: space-between;
   align-items: center;
 }
@@ -15,6 +14,9 @@
   align-items: center;
 
   a {
+    display: flex;
+    position: relative;
+
     margin-right: 0.75rem;
     padding-left: 0.75rem;
     color: $colors-gray-400;
@@ -76,7 +78,7 @@
 }
 
 .utilityButtonList {
-  display: inline-block;
+  display: flex;
   width: fit-content;
   height: fit-content;
   button {

--- a/src/components/Header/userMenu.module.scss
+++ b/src/components/Header/userMenu.module.scss
@@ -3,6 +3,7 @@
   justify-content: right;
   padding-top: 0.75rem;
   width: 65.625rem;
+  padding-bottom: 20px;
 
   li {
     @include paragraph-small;

--- a/src/styles/components/Footer/Footer.module.scss
+++ b/src/styles/components/Footer/Footer.module.scss
@@ -24,7 +24,7 @@
       justify-content: space-between;
       align-items: flex-start;
       padding: 28px 0px 32px;
-      gap: 150px;
+      gap: 87px;
     }
 
     &Bot {
@@ -46,7 +46,7 @@
     padding: 20px 4px 32px;
     gap: 4px;
 
-    width: 1920px;
+    width: 100%;
     height: 108px;
 
     background: $colors-gray-50;


### PR DESCRIPTION
## ✨ 구현 기능 개요
1. 헤더 레이아웃, 디테일 수정
2. 푸터 디테일 수정

## 🔨 작업사항
1. Header | 레이아웃 오류, 카테고리 메뉴 레이아웃 오류 해결 (#126)
- [x] variable.module.scss 적용 이후 버튼이 깨지는 문제 해결
- [x] 검색 input 우측 utility button 레이아웃 깨지는 문제 해결
- [x] category menu 위치, 배경색 문제 해결
- [x] 로고 상하 중앙 배치

2. Footer | 좌우 스크롤이 항상 활성화되어 있는 문제 해결 (#132)
- [x] Footer.module.scss의 49번째 행의 .bot 클래스의 width를 1920px -> 100%로 조절
- [x] 같은 파일의 27행의 푸터의 gap이 150px로 나머지 header, main 레이아웃보다 길어 피그마 시안에 맞춰 87px로 조절했습니다.

## ⏰ 소요시간
1시간 30분