### PR TITLE
[Feature] 동적라우팅 구축, 상품 디테일 페이지 firebase 데이터로 동적 렌더링 적용, 네비게이션 바 list페이지 접근 기능 구현

### DIFF
--- a/src/@store/detailCardState.js
+++ b/src/@store/detailCardState.js
@@ -24,3 +24,8 @@ export const productPrice = atom({
   key: 'price',
   default: 0,
 });
+
+export const productImgObject = atom({
+  key: 'ImgObject',
+  default: {},
+});

--- a/src/@store/detailPageProductInfo.js
+++ b/src/@store/detailPageProductInfo.js
@@ -1,0 +1,14 @@
+import { selectorFamily } from 'recoil';
+
+//fb
+import { dbService } from '@/routes/fbase';
+import { doc, getDoc } from 'firebase/firestore';
+
+export const recoilProductInfoSelector = selectorFamily({
+  key: 'InfoSelector',
+  get: (id) => async () => {
+    const docRef = doc(dbService, 'products', id);
+    const docSnap = await getDoc(docRef);
+    return docSnap.data();
+  },
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,10 @@ let router = createBrowserRouter([
       { path: 'Cart', element: <Cart /> },
       { path: 'Register', element: <Register /> },
       { path: 'List', element: <ProductList /> },
+      {
+        path: 'product/:id',
+        element: <ProductDetail />,
+      },
     ],
   },
 ]);
@@ -42,6 +46,7 @@ router = createBrowserRouter(
       <Route path="Cart" element={<Cart />} />
       <Route path="Register" element={<Register />} />
       <Route path="List" element={<ProductList />} />
+      <Route path="product/:id" element={<ProductDetail />} />
     </Route>
   )
 );

--- a/src/components/Header/Nav.jsx
+++ b/src/components/Header/Nav.jsx
@@ -4,6 +4,7 @@ import CategoryMenu from './CategoryMenu';
 import classes from '@/components/Header/nav.module.scss';
 
 import { SearchForm, UtilityButtonList } from './SearchBar';
+import { NavLink } from 'react-router-dom';
 
 export default function Nav(props) {
   return (
@@ -40,24 +41,28 @@ export function NavList({ ...rest }) {
   return (
     <li {...rest}>
       <ul>
-        <button type="button">
+        <NavLink>
           <span>신상품</span>
-        </button>
+        </NavLink>
       </ul>
+
       <ul>
-        <button type="button">
+        <NavLink
+          to="/list"
+          className={({ isActive }) => (isActive ? classes.active : '')}
+        >
           <span>베스트</span>
-        </button>
+        </NavLink>
       </ul>
       <ul>
-        <button type="button">
+        <NavLink>
           <span>알뜰쇼핑</span>
-        </button>
+        </NavLink>
       </ul>
       <ul>
-        <button type="button">
+        <NavLink>
           <span>특가/혜택</span>
-        </button>
+        </NavLink>
       </ul>
     </li>
   );

--- a/src/components/Header/nav.module.scss
+++ b/src/components/Header/nav.module.scss
@@ -126,20 +126,32 @@
   list-style: none;
   align-items: center;
 
-  button {
+  a {
+    display: flex;
     padding: 0;
     width: 9.375rem;
     height: 2.5rem;
-
+    justify-content: center;
+    align-items: center;
+    color: $colors-content;
     span {
-      padding-bottom: 0.125rem;
+      display: inline-block;
+      height: 24px;
+      @include label-medium;
     }
 
     &:hover {
       & span {
+        color: $colors-primary;
         border-bottom: 1px solid $colors-primary;
       }
     }
+  }
+}
+
+.active {
+  & span {
+    color: $colors-primary;
   }
 }
 

--- a/src/components/ProductCard/ProductCard.jsx
+++ b/src/components/ProductCard/ProductCard.jsx
@@ -1,41 +1,48 @@
-import productImg from '@/assets/img-zzol-vertical.png';
 import classes from '@/components/ProductCard/productCard.module.scss';
 import ProductMainInfo from './ProductMainInfo';
 import ProductDetailInfo from '@/components/ProductCard/ProductDetailInfo';
 import a11y from '@/styles/components/A11yHidden.module.scss';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { useLayoutEffect } from 'react';
 import {
   productID,
   productTitleState,
   productDescriptionState,
   productPrice,
+  productImgObject,
 } from '@/@store/detailCardState';
 
-const productInfo = {
-  productID: 'ttzm',
-  productName: '[풀무원] 탱탱쫄면(4개입)',
-  description: '튀기지 않아 부담 없는 매콤함',
-  price: 4980,
-};
+import { recoilProductInfoSelector } from '@/@store/detailPageProductInfo';
+import { useParams } from 'react-router-dom';
 
 export default function ProductCard() {
+  const params = useParams();
+  const contents = useRecoilValue(recoilProductInfoSelector(params.id));
+
+  if (!contents) {
+    alert('올바르지 않은 주소입니다.');
+    window.location.replace('/');
+  }
+
   const setProductID = useSetRecoilState(productID);
   const [title, setTitle] = useRecoilState(productTitleState);
   const [description, setDescription] = useRecoilState(productDescriptionState);
   const [price, setPrice] = useRecoilState(productPrice);
+  const [thumbnailImg, setThumbnailImg] = useRecoilState(productImgObject);
 
   useLayoutEffect(() => {
-    setProductID(productInfo.productID);
-    setTitle(productInfo.productName);
-    setDescription(productInfo.description);
-    setPrice(productInfo.price);
+    console.log(contents);
+    setProductID(params.id);
+    setTitle(contents.productName);
+    setDescription(contents.desc);
+    setPrice(contents.price);
+    setThumbnailImg(contents.image);
   }, []);
 
   return (
     <section className={classes.productCard}>
       <figure className={classes.productImgContainer}>
-        <img src={productImg} alt="탱탱 쫄면 제품 사진" />
+        <img src={thumbnailImg.thumbnail} alt={thumbnailImg.alt} />
         <figcaption className={a11y.srOnly}>탱탱 쫄면 제품 사진</figcaption>
       </figure>
       <div>


### PR DESCRIPTION
## ✨ 구현 기능 개요
1. 네비게이션 바 베스트 버튼 구현
2. 동적 라우팅 설정
3. Detail 페이지 Card 동적 렌더링
4. 오류 처리

## 🔨 작업사항
- [x] 베스트 버튼 활성화(누르면 list페이지로 이동합니다.) 
- [x] 네비게이션 바 NavLink로 바꾸고 isActive 적용
- [x] 동적라우팅
- [x] 디테일 페이지에 데이터 받아와서 뿌리기
- [x] 존재하지 않는 상품으로 접근시 알림 출력 및 홈으로 리다이렉션

## 추가 안내 사항
1. 디테일 페이지 접근 방법
![무제-1](https://user-images.githubusercontent.com/54176384/227784569-e1dcc807-fc7f-4d0f-a059-2ad48ef8b935.png)
![스크린샷 2023-03-26 오후 11 31 25](https://user-images.githubusercontent.com/54176384/227784612-e94846ad-6c20-4edb-a5ea-ddc86c59040a.png)

위 사진과 같이 파이어 베이스 내 각 상품 데이터를 담고있는 도큐먼트의 이름을 product/ 뒤에 붙여주면 됩니다. 
(ex. _http://localhost:3000/product/상품도큐먼트이름_)

@MIINII 정민님께서도 링크 구현시 product.id에 해당하는 값을 위에 제시한 주소형식에 맞추어 넣어주시면 될 것 같습니다!
개인적으로 자동으로 페이지 연결되는 것을 확인 했습니다.
![스크린샷 2023-03-26 오후 11 53 33](https://user-images.githubusercontent.com/54176384/227784118-47cbb757-9e89-4b0f-8432-2a677d9a6fd9.png)

@ukssss 장바구니 담기시 상품도큐먼트이름이 productID로 올라가니 참고해주시면 좋을 것 같습니다.
![스크린샷 2023-03-26 오후 11 34 07](https://user-images.githubusercontent.com/54176384/227784441-71b4ecc6-27e1-4838-88da-f0a7ec7fe753.png)

2. 존재하지 않는 상품으로 접근시 알림 출력 및 홈으로 리다이렉션
![스크린샷 2023-03-27 오전 12 00 45](https://user-images.githubusercontent.com/54176384/227784494-0875de60-7621-4a7f-baa0-b07436402118.png)

질문사항이나 이해가 잘 되지 않는 부분은 언제든지 질문 부탁드립니다.

## ⏰ 소요시간
8시간
